### PR TITLE
fix typo that is causing content-length header to append when it shouldn't

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function (blobs, url, opts) {
         if(!size) return next(new Error('no blob:'+hash))
 
         headers(res, hash)
-        if(opts.size === false || q.size)
+        if(opts.size !== false || q.size)
           res.setHeader('content-length', size)
 
         if(q.filename)


### PR DESCRIPTION
This is breaking inline display of secret blobs in patchwork.

Caused by a typo `=== false` instead of `!== false`.

Fixes ssbc/ssb-ws#10

@dominictarr 