### PR TITLE
Throw error on init if ssb-blobs is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ function headers(res, hash) {
 
 //host blobs
 module.exports = function (blobs, url, opts) {
+  if (!blobs) { 
+    throw new Error("multiblob-http failed to load because `blobs` is null. Did you load the ssb-blobs plugin?");
+  }
+
   opts = opts || {}
   return function (req, res, next) {
 


### PR DESCRIPTION
multiblob-http will not work if ssb-blobs is not loaded. Currently it will appear to work then crash after a blob is requested. To save users the headache of figuring out why their server is crashing throw an error on load if ssb-blobs isn't installed.

I originally added this to ssb-ws in https://github.com/ssbc/ssb-ws/pull/27 but I think this location is more appropriate, as multiblob-http could be used by other plugins in the future. 