### PR TITLE
remove dep "url-parse"

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,9 +38,9 @@ module.exports = function (blobs, url, opts) {
     else if(req.url.indexOf(url+'/get/') === 0) {
       if(!(req.method === "GET" || req.method === 'HEAD')) return next()
 
-      var u = urlParse('http://makeurlparseright.com'+req.url, true)
-      var hash = decodeURIComponent(u.pathname.substring((url+'/get/').length))
-      var q = u.query
+      const u = new URL('http://makeurlparseright.com'+req.url)
+      const hash = decodeURIComponent(u.pathname.substring((url+'/get/').length))
+      const q = Object.fromEntries(u.searchParams.entries())
 
       //if a browser revalidates, just tell them it hasn't changed, the hash has not changed.
       if(req.headers['if-none-match'] === hash) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var pull   = require('pull-stream')
 var toPull = require('stream-to-pull-stream')
 var many = require('pull-many')
-var urlParse = require('url-parse')
 var parseRange = require('range-parser')
 
 var YEAR = 60*60*24*365

--- a/package.json
+++ b/package.json
@@ -14,14 +14,16 @@
     "pull-many": "^1.0.9",
     "pull-stream": "^3.6.14",
     "range-parser": "^1.2.1",
-    "stream-to-pull-stream": "^1.7.3",
-    "url-parse": "^1.5.3"
+    "stream-to-pull-stream": "^1.7.3"
   },
   "devDependencies": {
     "bl": "^3.0.0",
     "hyperquest": "^2.1.3",
     "multiblob": "^1.13.7",
     "tape": "^5.3.1"
+  },
+  "engines": {
+    "node": ">=12"
   },
   "scripts": {
     "test": "tape test/*.js",


### PR DESCRIPTION
**Context:** The dependency `url-parse` keeps getting security alerts and security patches, and the best recommended action is to just replace it with the standard `URL()` constructor. `URL` is available in browsers since forever, and in Node.js since v7.0.0.

This PR replaces `url-parse` dependency with `new URL()`, and requires Node.js 12.0 and above (due to `URL` *and* some ES6 features like `const`)